### PR TITLE
#1 Support for battery level

### DIFF
--- a/temperature.py
+++ b/temperature.py
@@ -35,6 +35,8 @@ class WeatherStation:
 		try:
 			self.p = Peripheral(mac, ADDR_TYPE_RANDOM)
 			self.p.setDelegate(NotificationDelegate())
+			self.battery_svc = self.p.getServiceByUUID("0000180f-0000-1000-8000-00805f9b34fb")  # Standard Battery Service UUID
+			self.battery_char = self.battery_svc.getCharacteristics("00002a19-0000-1000-8000-00805f9b34fb")[0]  # Battery Level Characteristic UUID
 			logging.debug('WeatherStation connected !')
 		except BTLEException:
 			self.p = 0
@@ -130,6 +132,14 @@ class WeatherStation:
 			return temp
 		else:
 			return None
+
+	def readBatteryLevel(self):
+		if self.battery_char:
+				battery_level = self.battery_char.read()
+				battery_level = ord(battery_level)  # Convert byte to integer
+				logging.debug('Battery level: %d%%', battery_level)
+				return battery_level
+		return None
 			
 	def disconnect(self):
 		self.p.disconnect()
@@ -202,6 +212,7 @@ if __name__=="__main__":
 				# WeatherStation data received
 				indoor = weatherStation.getIndoorTemp()
 				outdoor = weatherStation.getOutdoorTemp()
+				battery_level = weatherStation.readBatteryLevel()
 			else:
 				logging.debug('No data received from WeatherStation')
 			


### PR DESCRIPTION
Resolves #1 

- [x] Try using `uuid=0x2A19` to get the battery level

## Testing

1. Scan for your device: `sudo hcitool lescan` - you should see something like: `<BLE ADDRESS> IDTW211R`
1. Try running the script: `python temperature.py <BLE ADDRESS>`

## Notes

I don't have a test device at home with me, so will have to try this during the week. If anyone has one they can test this with please let me know how it goes.